### PR TITLE
fix isZero

### DIFF
--- a/src/mappings/reputation/Reputation.ts
+++ b/src/mappings/reputation/Reputation.ts
@@ -1,7 +1,7 @@
 import 'allocator/arena'
 export { allocate_memory }
 
-import { Entity, Address, Value, store, crypto, ByteArray, BigInt } from '@graphprotocol/graph-ts'
+import { Address,store, crypto, } from '@graphprotocol/graph-ts'
 
 // Import event types from the Reputation contract ABI
 import { Mint, Burn ,Reputation} from '../../types/Reputation/Reputation'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,7 +40,6 @@ export function updateRedemption(beneficiary: Address, avatar: Address, amount: 
 export const zero256 = "0x0000000000000000000000000000000000000000000000000000000000000000"
 
 export function isZero(num: BigInt): boolean {
-  //return num[0] == 0 && num[1] == 0 && num[2] == 0 && num[3] == 0;
   for (let i = 0; i < num.length; i++) {
       if (num[i] != 0) {
         return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,5 +40,11 @@ export function updateRedemption(beneficiary: Address, avatar: Address, amount: 
 export const zero256 = "0x0000000000000000000000000000000000000000000000000000000000000000"
 
 export function isZero(num: BigInt): boolean {
-  return num[0] == 0 && num[1] == 0 && num[2] == 0 && num[3] == 0;
+  //return num[0] == 0 && num[1] == 0 && num[2] == 0 && num[3] == 0;
+  for (let i = 0; i < num.length; i++) {
+      if (num[i] != 0) {
+        return false;
+      }
+    }
+    return true;
 }

--- a/test/integration/Reputation.spec.ts
+++ b/test/integration/Reputation.spec.ts
@@ -9,6 +9,7 @@ describe('Reputation', () => {
     addresses = getContractAddresses();
     const opts = await getOptions(web3);
     reputation = new web3.eth.Contract(Reputation.abi, addresses.Reputation, opts);
+
   });
 
   async function checkTotalSupply(value) {
@@ -38,15 +39,12 @@ describe('Reputation', () => {
     txs.push(await reputation.methods.burn(accounts[0].address, '30').send());
     await checkTotalSupply('170');
 
-    //These tests have been comment out due to unknown issue at graph-node !!!
-    // Will bring these back as when it will be solved.
-
-    // txs.push(await reputation.methods.mint(accounts[2].address, '300').send());
-    // await checkTotalSupply('470');
-    // txs.push(await reputation.methods.burn(accounts[1].address, '100').send());
-    // await checkTotalSupply('370');
-    // txs.push(await reputation.methods.burn(accounts[2].address, '1').send());
-    // await checkTotalSupply('369');
+    txs.push(await reputation.methods.mint(accounts[2].address, '300').send());
+    await checkTotalSupply('470');
+    txs.push(await reputation.methods.burn(accounts[1].address, '100').send());
+    await checkTotalSupply('370');
+    txs.push(await reputation.methods.burn(accounts[2].address, '1').send());
+    await checkTotalSupply('369');
 
 
     txs = txs.map(({ transactionHash }) => transactionHash);
@@ -67,8 +65,8 @@ describe('Reputation', () => {
     })
     expect(reputationHolders).toContainEqual({
       contract: reputation.options.address.toLowerCase(),
-      address: accounts[1].address.toLowerCase(),
-      balance: '100'
+      address: accounts[2].address.toLowerCase(),
+      balance: '299'
     })
 
     const { reputationMints } = await query(`{
@@ -80,7 +78,7 @@ describe('Reputation', () => {
       }
     }`);
 
-    expect(reputationMints.length).toEqual(2);
+    expect(reputationMints.length).toEqual(3);
     expect(reputationMints).toContainEqual({
       txHash: txs[0],
       contract: reputation.options.address.toLowerCase(),
@@ -93,12 +91,12 @@ describe('Reputation', () => {
       address: accounts[1].address.toLowerCase(),
       amount: '100'
     });
-    // expect(reputationMints).toContainEqual({
-    //   txHash: txs[3],
-    //   contract: reputation.options.address.toLowerCase(),
-    //   address: accounts[2].address.toLowerCase(),
-    //   amount: '300'
-    // });
+    expect(reputationMints).toContainEqual({
+      txHash: txs[3],
+      contract: reputation.options.address.toLowerCase(),
+      address: accounts[2].address.toLowerCase(),
+      amount: '300'
+    });
 
     const { reputationBurns } = await query(`{
       reputationBurns {
@@ -109,24 +107,24 @@ describe('Reputation', () => {
       }
     }`);
 
-    expect(reputationBurns.length).toEqual(1);
+    expect(reputationBurns.length).toEqual(3);
     expect(reputationBurns).toContainEqual({
       txHash: txs[2],
       contract: reputation.options.address.toLowerCase(),
       address: accounts[0].address.toLowerCase(),
       amount: '30'
     });
-    // expect(reputationBurns).toContainEqual({
-    //   txHash: txs[4],
-    //   contract: reputation.options.address.toLowerCase(),
-    //   address: accounts[1].address.toLowerCase(),
-    //   amount: '100'
-    // });
-    // expect(reputationBurns).toContainEqual({
-    //   txHash: txs[5],
-    //   contract: reputation.options.address.toLowerCase(),
-    //   address: accounts[2].address.toLowerCase(),
-    //   amount: '1'
-    // });
+    expect(reputationBurns).toContainEqual({
+      txHash: txs[4],
+      contract: reputation.options.address.toLowerCase(),
+      address: accounts[1].address.toLowerCase(),
+      amount: '100'
+    });
+    expect(reputationBurns).toContainEqual({
+      txHash: txs[5],
+      contract: reputation.options.address.toLowerCase(),
+      address: accounts[2].address.toLowerCase(),
+      amount: '1'
+    });
   }, 100000)
 })

--- a/test/integration/util.ts
+++ b/test/integration/util.ts
@@ -15,7 +15,7 @@ import * as HDWallet from "hdwallet-accounts";
 
 const { node_http, ethereum, test_mnemonic } = process.env;
 
-export async function query(q: string, maxDelay = 500) {
+export async function query(q: string, maxDelay = 1000) {
     await new Promise((res, rej) => setTimeout(res, maxDelay));
     const {
         data: { data }


### PR DESCRIPTION
There was an index out of bounds in isZero because graph-node changed BigInt to be an array of bytes.

Now the rep test pass .
Need to add more 500 ms delay on tests.