### PR TITLE
Fix `npm run migrate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ In order to add support for a new contract follow these steps:
          map of solidity event signatures to event handlers in mapping code.
    4. `test/integration/<contract name>.spec.ts`
 
-3. (Optionally) add a deployment step for your contract in `ops/deployDaoStack.js` that will run before testing.
+3. (Optionally) add a deployment step for your contract in `ops/migrate.js` that will run before testing.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: '3'
 services:
   graph-node:
     image: graphprotocol/graph-node:latest@sha256:bc64577f8ed7d2a7badb575d85d99bf017bdddd68bf20b032c184654d27a4bef
-
-
     ports:
       - 8000:8000
       - 8001:8001

--- a/ops/migrate.js
+++ b/ops/migrate.js
@@ -1,0 +1,32 @@
+const path = require('path')
+const DAOstackMigration = require('@daostack/migration')
+const { migrationFileLocation } = require('./settings')
+
+async function migrate (options) {
+  let provider
+  if (process.env.ethereum) {
+    provider = process.env.ethereum
+  } else {
+    provider = 'http://localhost:8545'
+  }
+  options = {
+    // web3 provider url
+    provider,
+    quiet: true,
+    // disable confirmation messages
+    force: true,
+    // filepath to output the migration results
+    output: path.resolve(migrationFileLocation),
+    ...options
+  }
+
+  // migrate both base and an example DAO
+  const migrationResult = await DAOstackMigration.migrate(options) // migrate
+  return { options, migrationResult }
+}
+
+if (require.main === module) {
+  migrate().catch((err) => { console.log(err); process.exit(1) })
+} else {
+  module.exports = migrate
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"docker:logs": "docker-compose logs --follow",
 		"jest": "jest --runInBand --forceExit",
 		"lint": "tslint -c tslint.json 'src//**/*.ts' -e 'src//types/**/*.ts' && tslint -c tslint.json 'test/**/*.ts'",
-		"migrate": "node ops/deployDaoStack.js",
+		"migrate": "node ops/migrate.js",
 		"test": "npm run deploy && jest --runInBand --forceExit",
 		"test:watch": "npm run test -- --watch"
 	},


### PR DESCRIPTION
Repro:
`docker-compose up ganache`
`npm run migrate` (fails)
`npm run codegen` (requires migrate to succeed)

This was introduced here (deployDaoStack.js was deleted):
https://github.com/daostack/subgraph/commit/06f5745e089cde65fba6aad36b108a99645c132f#diff-e847897826ceb8346eb5141f8c23436a 