### PR TITLE
try fo fix the docker images

### DIFF
--- a/daos/private/test.json
+++ b/daos/private/test.json
@@ -1,0 +1,7 @@
+{
+    "name": "Uxorious Model",
+    "Avatar": "0xE7A2C59e134ee81D4035Ae6DB2254f79308e334f",
+    "DAOToken": "0xcDbe8b52A6c60A5f101d4A0F1f049f19a9e1D35F",
+    "Reputation": "0x93cdbf39fB9e13BD253CA5819247D52fbabf0F2f",
+    "Controller": "0xFcCeD5E997E7fb1D0594518D3eD57245bB8ed17E"
+}


### PR DESCRIPTION
The generated docker images break all the up-stream tests. There are two problems (a) the test dao is not added to the indexed cocntracts and (b) the graph-node starts up, but only indexes block 0


- for fix (a), I added a dao in `daos/private`. I copied the data from `migration.json` by hand, This should probably be done automatically in the `release.sh` script
- (b) was not a subgraph problem :-)