### PR TITLE
contractInfo creation : remove workaround for GenericScheme ->UGenericScheme

### DIFF
--- a/ops/generate-contractsinfo.js
+++ b/ops/generate-contractsinfo.js
@@ -30,11 +30,7 @@ async function generateContractInfo(opts={}) {
         let addresses = migration[network].base[version];
         for (var name in addresses) {
           if (addresses.hasOwnProperty(name)) {
-              if (name === "GenericScheme") {
-                buffer += "    setContractInfo("+"'"+addresses[name].toLowerCase()+"'"+", " +"'"+"UGenericScheme"+"'"+", "+"'"+"UGenericScheme"+"', "+"'"+version+"'"+");\n";
-              } else {
-                buffer += "    setContractInfo("+"'"+addresses[name].toLowerCase()+"'"+", " +"'"+name+"'"+", "+"'"+name+"', "+"'"+version+"'"+");\n";
-             }
+              buffer += "    setContractInfo("+"'"+addresses[name].toLowerCase()+"'"+", " +"'"+name+"'"+", "+"'"+name+"', "+"'"+version+"'"+");\n";
           }
         }
     }


### PR DESCRIPTION
For arc versions < 24 GenericScheme - is universal scheme.
For arc versions >= 24 GenericScheme is non universal scheme.
For arc versions >=24 UGenericScheme is universal scheme.



