### PR TITLE
Fix shared IPFS node URL

### DIFF
--- a/ops/graph-deploy.js
+++ b/ops/graph-deploy.js
@@ -45,7 +45,7 @@ async function deploy (opts = {}) {
   /* upload subgraph files to the shared IPFS node */
   let builtSubgraphId
   if (graphNode.match(/thegraph\.com/)) {
-    let sharedIpfsNode = ipfsNode.match(/staging/)
+    let sharedIpfsNode = graphNode.match(/staging/)
       ? 'https://api.staging.thegraph.com/ipfs/'
       : 'https://api.thegraph.com/ipfs/'
     result = await runGraphCli(['build', '--ipfs', sharedIpfsNode, opts.subgraphLocation])


### PR DESCRIPTION
The IPFS node URL is always `https://api.thegraph.com/ipfs-daostack/` now, so we have to test the Graph Node URL for whether it contains `staging` or not.