### PR TITLE
Bump graph-cli to 0.16.2 (fast IPFS upload)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,9 +128,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-      "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
+      "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -244,9 +244,9 @@
       }
     },
     "@graphprotocol/graph-cli": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.16.0.tgz",
-      "integrity": "sha512-tTpJc9waeRPzhF/aeWxu4jGW7GonVTQBeubTGVC6B2oFHpADXrQdthPgpmtThexXGHk46q14bHLuiSEm6ZBpkw==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.16.2.tgz",
+      "integrity": "sha512-6kaJmTQFj6BlDJfvoFnvcfy+a7nXlq7BVZqqrWHSXmKafr9IXVfuihFBOdXI5Sq+n09+bL4kZerd/cohnsWM3Q==",
       "requires": {
         "assemblyscript": "git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3",
         "chalk": "^2.4.1",
@@ -695,9 +695,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.144",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.144.tgz",
-      "integrity": "sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg=="
+      "version": "4.14.146",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.146.tgz",
+      "integrity": "sha512-JzJcmQ/ikHSv7pbvrVNKJU5j9jL9VLf3/gqs048CEnBVVVEv4kve3vLxoPHGvclutS+Il4SBIuQQ087m1eHffw=="
     },
     "@types/mocha": {
       "version": "5.2.7",
@@ -4380,9 +4380,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.1.tgz",
-      "integrity": "sha512-4FRPXWETxtigtJW/gxzEDsX1LVbPAM93VleB83kZB+ellqbHMkyt2aJfuzNLRvFPnGi6bcE5SvfxgbXPeKteJw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
       "optional": true
     },
     "fstream": {
@@ -6065,9 +6065,9 @@
       "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
     },
     "jayson": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.1.1.tgz",
-      "integrity": "sha512-w+RKdtrRNlqFlyDxcALzTrcKSwETYcU+P9/cqWn8RogXkcV9RSmdL1tUb6E8hglFh8r3I62vVP8xrXkaaKyQdQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.1.2.tgz",
+      "integrity": "sha512-EYGNAuffmuwSsoL+/wqaILH+2hhUJCdH/XIc+STshrIsS8yjFqYpBCn8qPHogtGl2Hq9/tJ4VoQ8V/tdZdaLDw==",
       "requires": {
         "@types/connect": "^3.4.32",
         "@types/express-serve-static-core": "^4.16.9",
@@ -6083,9 +6083,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.5.tgz",
-          "integrity": "sha512-KEjODidV4XYUlJBF3XdjSH5FWoMCtO0utnhtdLf1AgeuZLOrRbvmU/gaRCVg7ZaQDjVf3l84egiY0mRNe5xE4A=="
+          "version": "12.12.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
+          "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w=="
         }
       }
     },
@@ -8756,9 +8756,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.0.tgz",
-      "integrity": "sha512-uhnEDzAbrcJ8R3g2fANnSuXZMBtkpSjxTTgn2LeSiQlfmq72enQJWdQllXW24MBLYnA1SBD2vfvx2o0Zw3Ielw=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
+      "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA=="
     },
     "pify": {
       "version": "3.0.0",
@@ -8867,9 +8867,9 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
     },
     "pretty-format": {
       "version": "24.9.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "watch": "^1.0.2"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.16.0",
+    "@graphprotocol/graph-cli": "^0.16.2",
     "@graphprotocol/graph-ts": "0.16.0",
     "@types/node": "^10.14.4",
     "apollo-client": "^2.4.5",


### PR DESCRIPTION
@orenyodfat Little PR for you to speed up those `graph build` / `graph deploy` commands. Overall I think the whole `npm run deploy` procedure now takes approx. 100s instead of 30mins.