### PR TITLE
genesis alpha workaround

### DIFF
--- a/ops/generate-daos-subgraph.js
+++ b/ops/generate-daos-subgraph.js
@@ -46,8 +46,15 @@ function daoYaml(contract, contractAddress, arcVersion) {
                   file: path.resolve(`./abis/${arcVersion}/GenericScheme.json`)
                 };
         }
+        //this is temporary workaround (not nice) patch to solve an issue with multiple contract versions
+        //in genesis alpha dao
+        let _abiVersion = arcVersion;
+        if ((contractAddress == "0x211b9Bd0bCCACa64fB1d43093C75269bb84B3Be6") &&
+           (contractName == "GenericScheme")) {
+            _abiVersion = "0.0.1-rc.33";
+        }
         return {name: contractName,
-                file: path.resolve(`./abis/${arcVersion}/${contractName}.json`)
+                file: path.resolve(`./abis/${_abiVersion}/${contractName}.json`)
               };
       }),
       eventHandlers


### PR DESCRIPTION
a temporary workaround (not nice) patch to solve an issue with multiple contract versions in genesis alpha dao