### PR TITLE
do not register controllerCreator as a scheme

### DIFF
--- a/src/mappings/Controller/mapping.ts
+++ b/src/mappings/Controller/mapping.ts
@@ -58,7 +58,6 @@ function insertScheme(
 ): void {
   let controller = Controller.bind(controllerAddress);
   let perms = controller.getSchemePermissions(scheme, avatarAddress);
-  log.info('insertScheme avatar {} scheme {}', [avatarAddress.toHex(),scheme.toHex()])
   let controllerSchemeId = crypto.keccak256(concat(avatarAddress, scheme)).toHex();
   let controllerScheme = ControllerScheme.load(controllerSchemeId);
   if (controllerScheme === null) {
@@ -82,6 +81,11 @@ function insertScheme(
 
   let contractInfo = ContractInfo.load(scheme.toHex());
   if (contractInfo != null) {
+     if (contractInfo.name == "ControllerCreator") {
+       //this is a temporary workaround due to unexplained edge case where there is wrong ordering of events
+       //RegisterScheme come after UnRegisterScheme
+       return;
+     }
      controllerScheme.name = contractInfo.name;
      controllerScheme.version = contractInfo.version;
      controllerScheme.alias = contractInfo.alias;
@@ -90,7 +94,6 @@ function insertScheme(
 }
 
 function deleteScheme(avatarAddress: Address, scheme: Address): void {
-  log.info('deleteScheme avatar {} scheme {}', [avatarAddress.toHex(),scheme.toHex()])
   let id = crypto.keccak256(concat(avatarAddress, scheme)).toHex();
   let controllerScheme = ControllerScheme.load(id);
   if (controllerScheme != null) {
@@ -184,7 +187,7 @@ export function handleRegisterScheme(event: RegisterScheme): void {
   let avatar = controller.avatar();
 
   if (AvatarContract.load(avatar.toHex()) == null) {
-      log.info("handleRegisterSchemeO {}" ,[event.params._scheme.toHex()])
+      log.info("handleRegisterScheme avatar entity not exist {}" ,[event.params._scheme.toHex()])
       return;
   }
   let token = controller.nativeToken();

--- a/src/mappings/Controller/mapping.ts
+++ b/src/mappings/Controller/mapping.ts
@@ -7,6 +7,7 @@ import {
   crypto,
   Entity,
   store,
+  log
 } from '@graphprotocol/graph-ts';
 
 import { Avatar } from '../../types/Controller/Avatar';
@@ -57,6 +58,7 @@ function insertScheme(
 ): void {
   let controller = Controller.bind(controllerAddress);
   let perms = controller.getSchemePermissions(scheme, avatarAddress);
+  log.info('insertScheme avatar {} scheme {}', [avatarAddress.toHex(),scheme.toHex()])
   let controllerSchemeId = crypto.keccak256(concat(avatarAddress, scheme)).toHex();
   let controllerScheme = ControllerScheme.load(controllerSchemeId);
   if (controllerScheme === null) {
@@ -88,10 +90,17 @@ function insertScheme(
 }
 
 function deleteScheme(avatarAddress: Address, scheme: Address): void {
-  store.remove(
-    'ControllerScheme',
-    crypto.keccak256(concat(avatarAddress, scheme)).toHex(),
-  );
+  log.info('deleteScheme avatar {} scheme {}', [avatarAddress.toHex(),scheme.toHex()])
+  let id = crypto.keccak256(concat(avatarAddress, scheme)).toHex();
+  let controllerScheme = ControllerScheme.load(id);
+  if (controllerScheme != null) {
+      store.remove(
+        'ControllerScheme',
+        crypto.keccak256(concat(avatarAddress, scheme)).toHex(),
+      );
+  } else {
+    log.error('unregisterScheme none registered avatar {} , scheme {}', [avatarAddress.toHex(),scheme.toHex()]);
+  }
 }
 
 function insertOrganization(
@@ -175,6 +184,7 @@ export function handleRegisterScheme(event: RegisterScheme): void {
   let avatar = controller.avatar();
 
   if (AvatarContract.load(avatar.toHex()) == null) {
+      log.info("handleRegisterSchemeO {}" ,[event.params._scheme.toHex()])
       return;
   }
   let token = controller.nativeToken();

--- a/src/mappings/Controller/mapping.ts
+++ b/src/mappings/Controller/mapping.ts
@@ -6,8 +6,8 @@ import {
   Bytes,
   crypto,
   Entity,
+  log,
   store,
-  log
 } from '@graphprotocol/graph-ts';
 
 import { Avatar } from '../../types/Controller/Avatar';
@@ -81,9 +81,9 @@ function insertScheme(
 
   let contractInfo = ContractInfo.load(scheme.toHex());
   if (contractInfo != null) {
-     if (contractInfo.name == "ControllerCreator") {
-       //this is a temporary workaround due to unexplained edge case where there is wrong ordering of events
-       //RegisterScheme come after UnRegisterScheme
+     if (contractInfo.name === 'ControllerCreator') {
+       // this is a temporary workaround due to unexplained edge case where there is wrong ordering of events
+       // RegisterScheme come after UnRegisterScheme
        return;
      }
      controllerScheme.name = contractInfo.name;
@@ -102,7 +102,7 @@ function deleteScheme(avatarAddress: Address, scheme: Address): void {
         crypto.keccak256(concat(avatarAddress, scheme)).toHex(),
       );
   } else {
-    log.error('unregisterScheme none registered avatar {} , scheme {}', [avatarAddress.toHex(),scheme.toHex()]);
+    log.error('unregisterScheme none registered avatar {} , scheme {}', [avatarAddress.toHex(), scheme.toHex()]);
   }
 }
 
@@ -187,7 +187,7 @@ export function handleRegisterScheme(event: RegisterScheme): void {
   let avatar = controller.avatar();
 
   if (AvatarContract.load(avatar.toHex()) == null) {
-      log.info("handleRegisterScheme avatar entity not exist {}" ,[event.params._scheme.toHex()])
+      log.info('handleRegisterScheme avatar entity not exist {}' , [event.params._scheme.toHex()]);
       return;
   }
   let token = controller.nativeToken();


### PR DESCRIPTION
this is a temporary workaround due to unexplained edge case where there is wrong ordering of events
RegisterScheme come after UnRegisterScheme.
seems like there is an issue re indexing an event within a constructor with the current graph .
the graph team is working on a solution,.