### PR TITLE
Added dxDAO Token Registry Generic Schemes

### DIFF
--- a/daos/mainnet/dxdao.json
+++ b/daos/mainnet/dxdao.json
@@ -28,5 +28,23 @@
     "alias": "GenericSchemeENSRegistryWithFallback",
     "address": "0x9cea0dd05c4344a769b2f4c2f8890eda8a700d64",
     "arcVersion": "0.0.1-rc.36"
+  },
+  {
+    "name": "GenericScheme",
+    "alias": "GenericSchemeOmenTokenRegistry",
+    "address": "0x1f1d9cd773c762ccdd8216ce77a0574105cb4c39",
+    "arcVersion": "0.0.1-rc.39"
+  },
+  {
+    "name": "GenericScheme",
+    "alias": "GenericSchemeMixTokenRegistry",
+    "address": "0x3f56b94a1704253aee984571d113c7f4de7a2997",
+    "arcVersion": "0.0.1-rc.39"
+  },
+  {
+    "name": "GenericScheme",
+    "alias": "GenericSchemeExchangeTokenRegistry",
+    "address": "0x019199289a6fad231e60616b16e946ff6d9e631f",
+    "arcVersion": "0.0.1-rc.39"
   }]
 }

--- a/daos/mainnet/dxdao.json
+++ b/daos/mainnet/dxdao.json
@@ -32,19 +32,19 @@
   {
     "name": "GenericScheme",
     "alias": "GenericSchemeOmenTokenRegistry",
-    "address": "0x1f1d9cd773c762ccdd8216ce77a0574105cb4c39",
+    "address": "0xcb363df48fb6ecbf085305ca08883ed47f9161a5",
     "arcVersion": "0.0.1-rc.39"
   },
   {
     "name": "GenericScheme",
     "alias": "GenericSchemeMixTokenRegistry",
-    "address": "0x3f56b94a1704253aee984571d113c7f4de7a2997",
+    "address": "0xedec2c30a3b20dc96b809203b1fa1405ac63877c",
     "arcVersion": "0.0.1-rc.39"
   },
   {
     "name": "GenericScheme",
     "alias": "GenericSchemeExchangeTokenRegistry",
-    "address": "0x019199289a6fad231e60616b16e946ff6d9e631f",
+    "address": "0xe5b9a8470741fd0dcfcb21c6cb7a2799447a404d",
     "arcVersion": "0.0.1-rc.39"
   }]
 }

--- a/daos/rinkeby/dxdao.json
+++ b/daos/rinkeby/dxdao.json
@@ -4,5 +4,23 @@
   "DAOToken": "0xabC5784f7577F17085c85175A4ef185D8Db191d2",
   "Reputation": "0x11885c5e02f4A064d85c7e5c049518f837879a0F",
   "Controller": "0x1FEc243D5932c905Eb075819263aD9947B302D91",
-  "arcVersion": "0.0.1-rc.19"
+  "arcVersion": "0.0.1-rc.19",
+  "Schemes": [{
+    "name": "GenericScheme",
+    "alias": "GenericSchemeOmenTokenRegistry",
+    "address": "0x458bcd0cbb73abe3d6705ca758ad8d1228e8d623",
+    "arcVersion": "0.0.1-rc.39"
+  },
+  {
+    "name": "GenericScheme",
+    "alias": "GenericSchemeMixTokenRegistry",
+    "address": "0xf7c2204d07b289e6c462c7ee5d0be4a51943be67",
+    "arcVersion": "0.0.1-rc.39"
+  },
+  {
+    "name": "GenericScheme",
+    "alias": "GenericSchemeExchangeTokenRegistry",
+    "address": "0xae7a7ac6872359b161ec3cc05d91aa26980ff965",
+    "arcVersion": "0.0.1-rc.39"
+  }]
 }


### PR DESCRIPTION
Added Generic Schemes to be used by the dxDAO:

OmenTokenRegistry
MixTokenRegistry
ExchangeTokenRegistry