### PR TITLE
force set gp params

### DIFF
--- a/src/mappings/Controller/mapping.ts
+++ b/src/mappings/Controller/mapping.ts
@@ -288,8 +288,10 @@ export function handleRemoveGlobalConstraint(
 export function setGPParams(gpAddress: Address, gpParamsHash: Bytes, avatar: Address): void {
   let gp = GenesisProtocol.bind(gpAddress);
   let gpParams = GenesisProtocolParam.load(gpParamsHash.toHex());
-  if (gpParams == null && !equalsBytes(gpParamsHash, new Bytes(32))) {
-    gpParams = new GenesisProtocolParam(gpParamsHash.toHex());
+  if (!equalsBytes(gpParamsHash, new Bytes(32))) {
+    if (gpParams == null) {
+        gpParams = new GenesisProtocolParam(gpParamsHash.toHex());
+    }
     let callResult = gp.try_parameters(gpParamsHash);
     if (callResult.reverted) {
         log.info('genesisProtocol try_parameters reverted', []);


### PR DESCRIPTION
to solve edge case where the scheme gp params was not set in the genesis protocol..so the value in the entities are zero.
- unregister and register the scheme leave these value as zero.