### PR TITLE
Add CurveLabs necDAO for test purposes to rinkeby DAOs

### DIFF
--- a/daos/rinkeby/necdaocurvelabs.json
+++ b/daos/rinkeby/necdaocurvelabs.json
@@ -1,0 +1,23 @@
+{
+  "name": "necDAO",
+  "Avatar": "0x331dDC7Ed27451b5B4d25A41e8dF53cFF456DcA9",
+  "DAOToken": "0x6939C5672b575C2fa4E3393D1706c7A097219805",
+  "Reputation": "0x814d49253d595Ec7341e7307d2CB4964Ab9655F6",
+  "Controller": "0x5bdD6bdb6D35920DC1DeD2101Cb9b1D39DCEa92D",
+  "Schemes": [
+    {
+      "name": "UniswapProxy",
+      "alias": "UniswapProxy",
+      "address": "0x50AE25C926176D71F41A27Fe97fa4A7c31207131",
+      "arcVersion": "0.0.1-rc.44"
+    },
+    {
+      "name": "GenericScheme",
+      "alias": "Uniswap",
+      "address": "0xc3524072aa711f84d1Db93B1cdad68be176162bd",
+      "arcVersion": "0.0.1-rc.44"
+    }
+  ],
+  "StandAloneContracts": [],
+  "arcVersion": "0.0.1-rc.44"
+}


### PR DESCRIPTION
Hey,

Here is the PR to demo our Uniswap integration to our clients at necDAO.

The only thing I'm not sure of is: the `UniswapProxy` scheme comes with no specific frontend. Users will only interact with it through the `GenericScheme`. It's still registered as a scheme because it has the permission to call `genericCall` on the `Avatar` to `approve` ERC20 transfers.

I've added it to this file anyhow so that it displays a human-readable name instead of a contract address in the Alchemy schemes list. This will not cause a bug, right ?

Thanks for reviewing the PR anyhow.