### PR TITLE
Add necBurn and Uniswap schemes to necDAO

### DIFF
--- a/daos/mainnet/nectardao.json
+++ b/daos/mainnet/nectardao.json
@@ -6,6 +6,21 @@
   "Controller": "0x9f80898cC3Bc625b6A05B1500Adc7c4357eFb647",
   "Schemes": [
     {
+      "name": "UniswapProxy",
+      "alias": "UniswapProxy",
+      "address": "0x33ff117b155dc6cfa4168bab4ab492487ac767bd"
+    },
+    {
+      "name": "GenericScheme",
+      "alias": "Uniswap",
+      "address": "0x6d2c046f6d31374888a805ef041e62509efca367"
+    },
+    {
+      "name": "GenericScheme",
+      "alias": "necBurn",
+      "address": "0x8d8705016c8144cbd40c9302fdb3af88364f452c"
+    },
+    {
       "name": "GenericScheme",
       "alias": "GenericSchemeENSPublicProvider",
       "address": "0xD7aCd0a6985345810A0f87b58f4f90287cEa15Cc"


### PR DESCRIPTION
Hi,

We're about to be done with our work to enable `necDAO` to interact with `Uniswap` and their `necBurn` process.

All the addresses added in this PR are verified and can be checked. The related schemes are not registered in `necDAO` yet but are about to be through these three proposals: [here](https://alchemy.daostack.io/dao/0xe56b4d8d42b1c9ea7dda8a6950e3699755943de7/proposal/0x92e223f77e724577f874619ccba1882f91f4dbc3db1cf25587009a894bcc4722), [here](https://alchemy.daostack.io/dao/0xe56b4d8d42b1c9ea7dda8a6950e3699755943de7/proposal/0xf89eee4e77dc871ff1acc258001c6c9567efd0bc7ba1c69c1cef824bd2df467a) and [here](https://alchemy.daostack.io/dao/0xe56b4d8d42b1c9ea7dda8a6950e3699755943de7/proposal/0x45933d4feb3e0528c4aae62c926b97601d2fb9a34808aaecb2eb05256b22b35e).

Once the proposals have passed and this PR is merged I'll run a last batch of tests over our UX on mainnet and open a PR in the `alchemy` repo.

Bests.